### PR TITLE
16 DCAs total on this mixer, not 8

### DIFF
--- a/defstrip.json
+++ b/defstrip.json
@@ -71,7 +71,7 @@
 		"id": "dca",
 		"digits": 0,
 		"min": 1,
-		"max": 8,
+		"max": 16,
 		"description": "DCA Master",
 		"label": "DCA",
 		"act": "baseActions"


### PR DESCRIPTION
I've updated the defstrip.json file to reflect the total 16 DCAs on the Wing