### PR TITLE
Fix incorrect DCA count

### DIFF
--- a/defstrip.json
+++ b/defstrip.json
@@ -71,7 +71,7 @@
 		"id": "dca",
 		"digits": 0,
 		"min": 1,
-		"max": 8,
+		"max": 16,
 		"description": "DCA Master",
 		"label": "DCA",
 		"act": "baseActions"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"wing"
 	],
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Audio", "Mixer", "Console"


### PR DESCRIPTION
The module DCA channel count was 8. There are 16 DCA channels on the Wing.
Version Bump
(includes PR #10)
