### PR TITLE
Improve show control

### DIFF
--- a/src/actions/control.ts
+++ b/src/actions/control.ts
@@ -22,7 +22,7 @@ export function createControlActions(self: InstanceBaseExt<WingConfig>): Compani
 		[OtherActionId.RecallScene]: {
 			name: 'Recall Scene',
 			description:
-				'If you change the order of the scenes on your desk, restart the WING integration!. ATTENTION: if you have the same scene name twice in your show, you will not be able to recall it by name! In this case, use the scene ID instead.',
+				'ATTENTION: if you have the same scene name twice in your show, you will not be able to recall it by name! In this case, use the scene ID instead.',
 			options: [
 				{
 					type: 'checkbox',

--- a/src/actions/control.ts
+++ b/src/actions/control.ts
@@ -16,6 +16,7 @@ export function createControlActions(self: InstanceBaseExt<WingConfig>): Compani
 	const send = self.sendCommand
 	const state = self.state
 	const ensureLoaded = self.ensureLoaded
+	const subscriptions = self.subscriptions
 
 	const actions: { [id in OtherActionId]: CompanionActionWithCallback | undefined } = {
 		[OtherActionId.RecallScene]: {
@@ -59,9 +60,12 @@ export function createControlActions(self: InstanceBaseExt<WingConfig>): Compani
 				send(ControlCommands.LibraryAction(), 'GO')
 			},
 			subscribe: () => {
-				const cmd = ControlCommands.LibraryActiveSceneIndex()
-				ensureLoaded(cmd)
+				subscriptions.subscribePoll(ControlCommands.LibraryScenes())
+				ensureLoaded(ControlCommands.LibraryActiveSceneIndex())
 				ensureLoaded(ControlCommands.LibraryNode(), '?')
+			},
+			unsubscribe: () => {
+				subscriptions.unsubscribePoll(ControlCommands.LibraryScenes())
 			},
 			learn: (event) => {
 				const sceneIdMap = state.sceneNameToIdMap

--- a/src/actions/control.ts
+++ b/src/actions/control.ts
@@ -1,4 +1,4 @@
-import { CompanionActionDefinitions } from '@companion-module/base'
+import { CompanionActionDefinitions, CompanionOptionValues } from '@companion-module/base'
 import { CompanionActionWithCallback } from './common.js'
 import { InstanceBaseExt } from '../types.js'
 import { WingConfig } from '../config.js'
@@ -9,7 +9,6 @@ import { getIdLabelPair } from '../choices/utils.js'
 
 export enum OtherActionId {
 	RecallScene = 'recall-scene',
-	RecallSceneFromList = 'recall-scene-from-list',
 	SendLibraryAction = 'send-library-action',
 }
 
@@ -21,72 +20,57 @@ export function createControlActions(self: InstanceBaseExt<WingConfig>): Compani
 	const actions: { [id in OtherActionId]: CompanionActionWithCallback | undefined } = {
 		[OtherActionId.RecallScene]: {
 			name: 'Recall Scene',
-			description: 'Recall a scene and optionally go to it',
+			description: 'If you change the order of the scenes on your desk, restart the WING integration!',
 			options: [
 				{
+					type: 'checkbox',
+					id: 'useSceneId',
+					label: 'Use Scene Id',
+					default: false,
+				},
+				{
 					type: 'number',
-					id: 'num',
+					id: 'sceneId',
 					label: 'Scene Number',
 					min: 1,
 					max: 16384,
 					default: 1,
+					isVisible: (options: CompanionOptionValues): boolean => {
+						return options.useSceneId != null && options.useSceneId == true
+					},
 				},
 				{
-					type: 'checkbox',
-					id: 'go',
-					label: 'Go to Scene?',
-					default: true,
+					...GetDropdown('Scene Name', 'sceneName', state.namedChoices.scenes),
+					isVisible: (options: CompanionOptionValues): boolean => {
+						return options.useSceneId != null && options.useSceneId == false
+					},
 				},
 			],
 			callback: async (event) => {
-				send(ControlCommands.LibrarySceneSelectionIndex(), event.options.num as number)
-				if (event.options.go) {
-					send(ControlCommands.LibraryAction(), 'GO')
+				const useSceneId = event.options.useSceneId
+				let sceneId = 0
+				if (useSceneId == true) {
+					sceneId = event.options.sceneId as number
+				} else {
+					sceneId = state.sceneNameToIdMap.get(event.options.sceneName as string) ?? 0
 				}
-			},
-			subscribe: () => {
-				const cmd = ControlCommands.LibraryActiveSceneIndex()
-				ensureLoaded(cmd)
-			},
-			learn: () => {
-				const cmd = ControlCommands.LibraryActiveSceneIndex()
-				return { num: StateUtil.getNumberFromState(cmd, state) }
-			},
-		},
-		[OtherActionId.RecallSceneFromList]: {
-			name: 'Recall Scene from List',
-			description:
-				'Recall a scene from a list and optionally go to it (NOTE: When you add/remove/move scenes in your show, you must update this command.)',
-			options: [
-				GetDropdown(
-					'Scene',
-					'num',
-					state.namedChoices.scenes,
-					undefined,
-					'This uses the index of the scene, and changes when scenes are added or removed.',
-				),
-				{
-					type: 'checkbox',
-					id: 'go',
-					label: 'Go to Scene?',
-					default: true,
-				},
-			],
-			callback: async (event) => {
-				const go = event.options.go as boolean
-				send(ControlCommands.LibrarySceneSelectionIndex(), event.options.num as number)
-				if (go) {
-					send(ControlCommands.LibraryAction(), 'GO')
-				}
+				send(ControlCommands.LibrarySceneSelectionIndex(), sceneId)
+				send(ControlCommands.LibraryAction(), 'GO')
 			},
 			subscribe: () => {
 				const cmd = ControlCommands.LibraryActiveSceneIndex()
 				ensureLoaded(cmd)
 				ensureLoaded(ControlCommands.LibraryNode(), '?')
 			},
-			learn: () => {
+			learn: (event) => {
+				const sceneIdMap = state.sceneNameToIdMap
 				const cmd = ControlCommands.LibraryActiveSceneIndex()
-				return { num: StateUtil.getNumberFromState(cmd, state) }
+				const sceneId = StateUtil.getNumberFromState(cmd, state)
+				let sceneName = ''
+				for (const [key, value] of sceneIdMap.entries()) {
+					if (value === sceneId) sceneName = key
+				}
+				return { sceneName: sceneName, sceneId: sceneId, useSceneId: event.options.useSceneId }
 			},
 		},
 		[OtherActionId.SendLibraryAction]: {

--- a/src/actions/control.ts
+++ b/src/actions/control.ts
@@ -20,7 +20,8 @@ export function createControlActions(self: InstanceBaseExt<WingConfig>): Compani
 	const actions: { [id in OtherActionId]: CompanionActionWithCallback | undefined } = {
 		[OtherActionId.RecallScene]: {
 			name: 'Recall Scene',
-			description: 'If you change the order of the scenes on your desk, restart the WING integration!',
+			description:
+				'If you change the order of the scenes on your desk, restart the WING integration!. ATTENTION: if you have the same scene name twice in your show, you will not be able to recall it by name! In this case, use the scene ID instead.',
 			options: [
 				{
 					type: 'checkbox',

--- a/src/actions/control.ts
+++ b/src/actions/control.ts
@@ -59,13 +59,12 @@ export function createControlActions(self: InstanceBaseExt<WingConfig>): Compani
 				send(ControlCommands.LibrarySceneSelectionIndex(), sceneId)
 				send(ControlCommands.LibraryAction(), 'GO')
 			},
-			subscribe: () => {
-				subscriptions.subscribePoll(ControlCommands.LibraryScenes())
+			subscribe: (event) => {
+				if (event.options.useSceneId == false) {
+					subscriptions.subscribePoll(ControlCommands.LibraryScenes())
+				}
 				ensureLoaded(ControlCommands.LibraryActiveSceneIndex())
 				ensureLoaded(ControlCommands.LibraryNode(), '?')
-			},
-			unsubscribe: () => {
-				subscriptions.unsubscribePoll(ControlCommands.LibraryScenes())
 			},
 			learn: (event) => {
 				const sceneIdMap = state.sceneNameToIdMap

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import { WingDeviceDetectorInstance } from './device-detector.js'
 // import { ModelChoices, WingModel } from './models/types.js'
 
 export const fadeUpdateRateDefault = 50
-export const pollUpdateRateDefault = 500
+export const pollUpdateRateDefault = 3000
 
 export const DeskTypes = [
 	{ id: 'wing', label: 'Wing' },

--- a/src/feedbacks.ts
+++ b/src/feedbacks.ts
@@ -11,13 +11,7 @@ import {
 	CompanionFeedbackInfo,
 } from '@companion-module/base'
 // import { compareNumber, GetDropdownFeedback, GetNumberComparator, GetPanoramaSliderFeedback } from './choices/common.js'
-import {
-	GetDropdown,
-	GetMuteDropdown,
-	getTimeFormatChoices,
-	getTriStateColor,
-	getTriStateTextColor,
-} from './choices/common.js'
+import { GetDropdown, GetMuteDropdown, getTriStateColor, getTriStateTextColor } from './choices/common.js'
 import { getNodeNumber } from './actions/utils.js'
 import { StateUtil } from './state/index.js'
 import { UsbPlayerCommands } from './commands/usbplayer.js'
@@ -34,9 +28,7 @@ export enum FeedbackId {
 	Mute = 'mute',
 	SendMute = 'send-mute',
 	AesStatus = 'aes-status',
-	RecorderTime = 'recorder-time',
 	RecorderState = 'recorder-state',
-	PlayerTime = 'player-time',
 }
 
 function subscribeFeedback(
@@ -160,33 +152,6 @@ export function GetFeedbacksList(
 				unsubscribeFeedback(subs, cmd, event)
 			},
 		},
-		[FeedbackId.RecorderTime]: {
-			type: 'advanced',
-			name: 'USB Recorder Time',
-			description: 'Current Time of the Recording',
-			options: [GetDropdown('Format', 'format', getTimeFormatChoices())],
-			callback: (): CompanionAdvancedFeedbackResult => {
-				const cmd = UsbPlayerCommands.RecorderTime()
-				const time = StateUtil.getNumberFromState(cmd, state) ?? 'N/A'
-				if (time) {
-					if (isNaN(Number(time))) {
-						return {
-							text: time as string,
-						}
-					} else return {}
-				} else return {}
-			},
-			subscribe: (event): void => {
-				const cmd = UsbPlayerCommands.RecorderTime()
-				subs.subscribePoll(cmd, event.id, event.feedbackId as FeedbackId)
-				subscribeFeedback(ensureLoaded, subs, cmd, event)
-			},
-			unsubscribe: (event: CompanionFeedbackInfo): void => {
-				const cmd = UsbPlayerCommands.RecorderTime()
-				subs.unsubscribePoll(cmd, event.feedbackId as FeedbackId)
-				unsubscribeFeedback(subs, cmd, event)
-			},
-		},
 		[FeedbackId.RecorderState]: {
 			type: 'advanced',
 			name: 'USB Recorder State',
@@ -233,28 +198,6 @@ export function GetFeedbacksList(
 			},
 			unsubscribe: (event: CompanionFeedbackInfo): void => {
 				const cmd = UsbPlayerCommands.RecorderActiveState()
-				unsubscribeFeedback(subs, cmd, event)
-			},
-		},
-		[FeedbackId.PlayerTime]: {
-			type: 'advanced',
-			name: 'USB Player Time',
-			description: 'Current Time of the USB Player',
-			options: [GetDropdown('Format', 'format', getTimeFormatChoices())],
-			callback: (): CompanionAdvancedFeedbackResult => {
-				const cmd = UsbPlayerCommands.PlayerTotalTime()
-				return {
-					text: `${StateUtil.getNumberFromState(cmd, state) ?? 'N/A'}`,
-				}
-			},
-			subscribe: (event): void => {
-				const cmd = UsbPlayerCommands.PlayerTotalTime()
-				subs.subscribePoll(cmd, event.id, event.feedbackId as FeedbackId)
-				subscribeFeedback(ensureLoaded, subs, cmd, event)
-			},
-			unsubscribe: (event: CompanionFeedbackInfo): void => {
-				const cmd = UsbPlayerCommands.PlayerTotalTime()
-				subs.unsubscribePoll(cmd, event.feedbackId as FeedbackId)
 				unsubscribeFeedback(subs, cmd, event)
 			},
 		},

--- a/src/index.ts
+++ b/src/index.ts
@@ -333,7 +333,8 @@ export class WingInstance extends InstanceBase<WingConfig> implements InstanceBa
 			console.log(scenes)
 			if (scenes) {
 				const sceneList = scenes[1].split(',').map((s) => s.trim())
-				this.state.namedChoices.scenes = sceneList.map((s, i) => ({ id: i + 1, label: s }))
+				this.state.namedChoices.scenes = sceneList.map((s) => ({ id: s, label: s }))
+				this.state.sceneNameToIdMap = new Map(sceneList.map((s, i) => [s, i + 1]))
 			}
 		}
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -327,8 +327,7 @@ export class WingInstance extends InstanceBase<WingConfig> implements InstanceBa
 
 		// scene list
 		if (libRe.test(msg.address)) {
-			console.log('Got library')
-			const content = (args[0].value as string) ?? ''
+			const content = String(args[0]?.value ?? '')
 			const scenes = content.match(/\$scenes\s+list\s+\[([^\]]+)\]/)
 			console.log(scenes)
 			if (scenes) {

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -267,12 +267,10 @@ export class WingSubscriptions {
 	public getPollPaths(): string[] {
 		return Array.from(this.pollData)
 	}
-	public subscribePoll(path: string, feedbackId: string, type: FeedbackId): void {
-		this.subscribe(path, feedbackId, type)
+	public subscribePoll(path: string): void {
 		this.pollData.add(path)
 	}
-	public unsubscribePoll(path: string, feedbackId: string): void {
-		this.unsubscribe(path, feedbackId)
+	public unsubscribePoll(path: string): void {
 		this.pollData.delete(path)
 	}
 }

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -53,11 +53,14 @@ export class WingState implements IStoredChannelSubject {
 		scenes: [],
 	}
 
+	sceneNameToIdMap: Map<string, number>
+
 	constructor(model: ModelSpec) {
 		this.data = new Map()
 		this.pressStorage = new Map()
 		this.deltaStorage = new Map()
 		this.storedChannel = 1
+		this.sceneNameToIdMap = new Map()
 		this.updateNames(model)
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,14 @@
 import { InstanceBase } from '@companion-module/base'
 import osc from 'osc'
 import { WingTransitions } from './transitions.js'
-import { WingState } from './state/state.js'
+import { WingState, WingSubscriptions } from './state/state.js'
 
 export interface InstanceBaseExt<TConfig> extends InstanceBase<TConfig> {
 	config: TConfig
 	osc: osc.UDPPort
 	transitions: WingTransitions
 	state: WingState
+	subscriptions: WingSubscriptions
 	sendCommand: (cmd: string, argument?: number | string, preferFloat?: boolean) => void
 	ensureLoaded: (path: string, arg?: string | number) => void
 }

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -205,6 +205,7 @@ export function UpdateVariableDefinitions(self: WingInstance): void {
 	variables.push({ variableId: 'active_show_name', name: 'Active Show Name' })
 	variables.push({ variableId: 'active_scene_number', name: 'Active Scene Number' })
 	variables.push({ variableId: 'active_scene_name', name: 'Active Scene Name' })
+	variables.push({ variableId: 'active_scene_folder', name: 'Active Scene Folder' })
 
 	self.setVariableDefinitions(variables)
 }
@@ -429,24 +430,30 @@ function UpdateGpioVariables(self: WingInstance, path: string, value: number): v
 }
 
 function UpdateControlVariables(self: WingInstance, path: string, args: OSCMetaArgument): void {
-	const match = path.match(/^\/\$ctl\/lib\/(\$?\w+)/)
-	if (!match) {
-		return
-	}
+	const pathMatch = path.match(/^\/\$ctl\/lib\/(\$?\w+)/)
+	if (!pathMatch) return
 
-	const command = match[1]
+	const command = pathMatch[1]
 
-	if (command == '$actshow') {
-		const showname = args.value as string
+	if (command === '$actshow') {
+		const fullShowPath = String(args.value)
+		const showMatch = fullShowPath.match(/([^/\\]+)(?=\.show$)/)
+		const showname = showMatch?.[1] ?? 'N/A'
 		self.setVariableValues({ active_show_name: showname })
-	} else if (command == '$actidx') {
+	} else if (command === '$actidx') {
 		const index = args.value as number
 		self.setVariableValues({ active_scene_number: index })
-	} else if (command == '$active') {
-		const scene = args.value as string
-		self.setVariableValues({ active_scene_name: scene })
-	} else if (command == '$scenes') {
-		// need to request full list of scenes
+	} else if (command === '$active') {
+		const fullScenePath = String(args.value)
+		const sceneMatch = fullScenePath.match(/([^/\\]+)[/\\]([^/\\]+)\..*$/)
+		const scene = sceneMatch?.[2] ?? 'N/A'
+		const parent = sceneMatch?.[1] ?? 'N/A'
+
+		self.setVariableValues({
+			active_scene_name: scene,
+			active_scene_folder: parent,
+		})
+	} else if (command === '$scenes') {
 		self.sendCommand(ControlCommands.LibraryNode(), '?')
 	}
 }


### PR DESCRIPTION
Closes #50 

Hi @elliotmatson 

I was messing around with show control a bit and tried two things:

- merge the recall-scene and recall-scene-from-list command
- get the recall-scene-from-list command to not get messed up when rearranging scenes

The first point is easy to do, I simply added a checkmark to select the recall type.

For the second one, I keep track of the scene name to scene ID mapping and create the scene list by having the scene name both be the id and the label. Doing it this way does not mess up the selected scene.

When using the scene selector, a poll subscription is activated. This generates a bit of data, but should not be too heavy. If there is no scene selection active, there will be no transfer of this information.

Selecting the scenes by name of course makes it impossible to have the same scene name multiple times. For now, I added a disclaimer to the command. I think this is an ok compromise.