### PR TITLE
Send actions unification and misc cleanup

### DIFF
--- a/src/actions/bus.ts
+++ b/src/actions/bus.ts
@@ -1,53 +1,12 @@
 import { CompanionActionDefinitions } from '@companion-module/base'
-import { GetFaderInputField, GetDropdown, GetMuteDropdown } from '../choices/common.js'
-import { getNodeNumber, runTransition } from './utils.js'
 import { CompanionActionWithCallback } from './common.js'
-import { BusCommands as Commands } from '../commands/bus.js'
 import { InstanceBaseExt } from '../types.js'
 import { WingConfig } from '../config.js'
 
-export enum BusActions {
-	SetBusToMatrixLevel = 'set-bus-to-matrix-level',
-	SetBusToMatrixMute = 'set-bus-to-matrix-mute',
-}
+export enum BusActions {}
 
-export function createBusActions(self: InstanceBaseExt<WingConfig>): CompanionActionDefinitions {
-	const send = self.sendCommand
-	const ensureLoaded = self.ensureLoaded
-	const state = self.state
-	const transitions = self.transitions
-
-	const actions: { [id in BusActions]: CompanionActionWithCallback | undefined } = {
-		[BusActions.SetBusToMatrixLevel]: {
-			name: 'Set Bus to Matrix Level',
-			description: 'Set the level of a bus to matrix send.',
-			options: [
-				GetDropdown('From Bus', 'bus', state.namedChoices.busses),
-				GetDropdown('To Matrix', 'matrix', state.namedChoices.matrices),
-				...GetFaderInputField('level'),
-			],
-			callback: async (event) => {
-				const cmd = Commands.MatrixSendLevel(getNodeNumber(event, 'bus'), getNodeNumber(event, 'matrix'))
-				runTransition(cmd, 'level', event, state, transitions)
-			},
-			subscribe: (event) => {
-				ensureLoaded(Commands.MatrixSendLevel(getNodeNumber(event, 'bus'), getNodeNumber(event, 'matrix')))
-			},
-		},
-		[BusActions.SetBusToMatrixMute]: {
-			name: 'Set Bus to Matrix Mute',
-			description: 'Set the state of a bus to matrix mute.',
-			options: [
-				GetDropdown('From Bus', 'bus', state.namedChoices.busses),
-				GetDropdown('To Matrix', 'matrix', state.namedChoices.matrices),
-				GetMuteDropdown('mute'),
-			],
-			callback: async (event) => {
-				const cmd = Commands.MatrixSendOn(getNodeNumber(event, 'bus'), getNodeNumber(event, 'matrix'))
-				send(cmd, event.options.mute as number)
-			},
-		},
-	}
+export function createBusActions(_self: InstanceBaseExt<WingConfig>): CompanionActionDefinitions {
+	const actions: { [id in BusActions]: CompanionActionWithCallback | undefined } = {}
 
 	return actions
 }

--- a/src/actions/cards.ts
+++ b/src/actions/cards.ts
@@ -45,6 +45,7 @@ export function createCardsActions(self: InstanceBaseExt<WingConfig>): Companion
 		},
 		[CardsActionId.SetAutoInput]: {
 			name: 'WLive: Set Auto Input',
+			description: 'Set which cards should be used for auto input selection.',
 			options: [GetDropdown('Selection', 'selection', getCardsAutoInChoices())],
 			callback: async (event) => {
 				const cmd = Commands.WLiveAutoIn()
@@ -53,6 +54,7 @@ export function createCardsActions(self: InstanceBaseExt<WingConfig>): Companion
 		},
 		[CardsActionId.SetAutoStop]: {
 			name: 'WLive: Set Auto Stop',
+			description: 'Set input actions on stop',
 			options: [GetDropdown('Selection', 'selection', getCardsAutoRoutingChoices())],
 			callback: async (event) => {
 				const cmd = Commands.WLiveAutoStop()
@@ -61,6 +63,7 @@ export function createCardsActions(self: InstanceBaseExt<WingConfig>): Companion
 		},
 		[CardsActionId.SetAutoPlay]: {
 			name: 'WLive: Set Auto Play',
+			description: 'Set input actions on play',
 			options: [GetDropdown('Selection', 'selection', getCardsAutoRoutingChoices())],
 			callback: async (event) => {
 				const cmd = Commands.WLiveAutoPlay()
@@ -69,6 +72,7 @@ export function createCardsActions(self: InstanceBaseExt<WingConfig>): Companion
 		},
 		[CardsActionId.SetAutoRecord]: {
 			name: 'WLive: Set Auto Record',
+			description: 'Set input actions on record',
 			options: [GetDropdown('Selection', 'selection', getCardsAutoRoutingChoices())],
 			callback: async (event) => {
 				const cmd = Commands.WLiveAutoRecord()

--- a/src/actions/common.ts
+++ b/src/actions/common.ts
@@ -531,12 +531,13 @@ export function createCommonActions(self: InstanceBaseExt<WingConfig>): Companio
 		////////////////////////////////////////////////////////////////
 		[CommonActions.SetDelay]: {
 			name: 'Set Delay',
-			description: 'Enable or disable the delay of a bus, matrix or main.',
+			description: 'Enable or disable the delay of a channel, bus, matrix or main.',
 			options: [
 				GetDropdown('Selection', 'sel', [
-					...state.namedChoices.mains,
+					...state.namedChoices.channels,
 					...state.namedChoices.matrices,
 					...state.namedChoices.busses,
+					...state.namedChoices.mains,
 				]),
 				GetOnOffToggleDropdown('delay', 'Delay'),
 			],
@@ -560,12 +561,13 @@ export function createCommonActions(self: InstanceBaseExt<WingConfig>): Companio
 
 		[CommonActions.SetDelayAmount]: {
 			name: 'Set Delay Mode',
-			description: 'Set the delay mode of a bus, matrix or main.',
+			description: 'Set the delay mode of a channel, bus, matrix or main.',
 			options: [
 				GetDropdown('Selection', 'sel', [
-					...state.namedChoices.mains,
+					...state.namedChoices.channels,
 					...state.namedChoices.matrices,
 					...state.namedChoices.busses,
+					...state.namedChoices.mains,
 				]),
 				GetDropdown('Delay Mode', 'mode', getDelayModes()),
 				{

--- a/src/actions/common.ts
+++ b/src/actions/common.ts
@@ -54,8 +54,12 @@ export enum CommonActions {
 	// Delay
 	SetDelay = 'set-delay',
 	SetDelayAmount = 'set-delay-amount',
+	// Gate
+	SetGateOn = 'set-gate-on',
 	// EQ
 	SetEqOn = 'set-eq-on',
+	// Dynamics
+	SetDynamicsOn = 'set-dynamics-on',
 
 	//////////// SEND
 	SetSendMute = 'set-send-mute',
@@ -659,6 +663,36 @@ export function createCommonActions(self: InstanceBaseExt<WingConfig>): Companio
 				}
 			},
 		},
+		////////////////////////////////////////////////////////////////
+		// Gate
+		////////////////////////////////////////////////////////////////
+		[CommonActions.SetGateOn]: {
+			name: 'Set Gate On',
+			description: 'Enable, disable or toggle the on-state of a gate on a channel',
+			options: [
+				GetDropdown('Selection', 'sel', state.namedChoices.channels),
+				GetOnOffToggleDropdown('enable', 'Enable'),
+			],
+			callback: async (event) => {
+				const sel = event.options.sel as string
+				const cmd = ActionUtil.getGateEnableCommand(sel, getNodeNumber(event, 'sel'))
+				const val = ActionUtil.getNumber(event, 'enable')
+				if (val < 2) {
+					send(cmd, val)
+				} else {
+					const currentVal = StateUtil.getBooleanFromState(cmd, state)
+					send(cmd, Number(!currentVal))
+				}
+			},
+			subscribe: (event) => {
+				const sel = event.options.sel as string
+				const cmd = ActionUtil.getGateEnableCommand(sel, getNodeNumber(event, 'sel'))
+				ensureLoaded(cmd)
+			},
+		},
+		////////////////////////////////////////////////////////////////
+		// EQ
+		////////////////////////////////////////////////////////////////
 		[CommonActions.SetEqOn]: {
 			name: 'Set EQ On',
 			description: 'Enable, disable or toggle the on-state of an EQ on a channel, bus, aux, matrix or main.',
@@ -680,7 +714,30 @@ export function createCommonActions(self: InstanceBaseExt<WingConfig>): Companio
 				ensureLoaded(cmd)
 			},
 		},
-
+		////////////////////////////////////////////////////////////////
+		// Dynamics
+		////////////////////////////////////////////////////////////////
+		[CommonActions.SetDynamicsOn]: {
+			name: 'Set Dynamics On',
+			description: 'Enable, disable or toggle the on-state of dynamics on a channel, bus, aux, matrix or main.',
+			options: [GetDropdown('Selection', 'sel', allChannels), GetOnOffToggleDropdown('enable', 'Enable')],
+			callback: async (event) => {
+				const sel = event.options.sel as string
+				const cmd = ActionUtil.getDynamicsEnableCommand(sel, getNodeNumber(event, 'sel'))
+				const val = ActionUtil.getNumber(event, 'enable')
+				const currentVal = StateUtil.getBooleanFromState(cmd, state)
+				if (val < 2) {
+					send(cmd, val)
+				} else {
+					send(cmd, Number(!currentVal))
+				}
+			},
+			subscribe: (event) => {
+				const sel = event.options.sel as string
+				const cmd = ActionUtil.getDynamicsEnableCommand(sel, getNodeNumber(event, 'sel'))
+				ensureLoaded(cmd)
+			},
+		},
 		////////////////////////////////////////////////////////////////
 		// Send Fader
 		////////////////////////////////////////////////////////////////

--- a/src/actions/utils.ts
+++ b/src/actions/utils.ts
@@ -16,6 +16,10 @@ export function getNodeNumber(action: CompanionActionInfo | CompanionFeedbackInf
 	return action.options[id]?.toString().split('/')[2] as unknown as number
 }
 
+export function getNodeNumberFromID(id: string): number {
+	return id.split('/')[2] as unknown as number
+}
+
 export function getNumber(action: CompanionActionInfo, key: string, defaultValue?: number): number {
 	const rawVal = action.options[key]
 	if (defaultValue !== undefined && rawVal === undefined) {
@@ -238,36 +242,88 @@ export function getDelayAmountCommand(sel: string, val: number): string {
 	return cmd
 }
 
-export function getSendMuteCommand(sel: string, src: number, dest: number): string {
+export function getSendMuteCommand(src: string, dest: string): string {
 	let cmd = ''
-	if (sel.startsWith('/ch')) {
-		cmd = ChannelCommands.SendOn(src, dest)
-	} else if (sel.startsWith('/aux')) {
-		cmd = AuxCommands.SendOn(src, dest)
-	} else if (sel.startsWith('/bus')) {
-		cmd = BusCommands.SendOn(src, dest)
+	if (src.startsWith('/ch')) {
+		if (dest.startsWith('/bus')) {
+			cmd = ChannelCommands.SendOn(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		} else if (dest.startsWith('/mtx')) {
+			cmd = ChannelCommands.MatrixSendOn(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		} else if (dest.startsWith('/main')) {
+			cmd = ChannelCommands.MainSendOn(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		}
+	} else if (src.startsWith('/aux')) {
+		if (dest.startsWith('/bus')) {
+			cmd = AuxCommands.SendOn(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		} else if (dest.startsWith('/mtx')) {
+			cmd = AuxCommands.MatrixSendOn(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		} else if (dest.startsWith('/main')) {
+			cmd = AuxCommands.MainSendOn(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		}
+	} else if (src.startsWith('/bus')) {
+		if (dest.startsWith('/bus')) {
+			cmd = BusCommands.SendOn(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		} else if (dest.startsWith('/mtx')) {
+			cmd = BusCommands.MatrixSendOn(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		} else if (dest.startsWith('/main')) {
+			cmd = BusCommands.MainSendOn(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		}
+	} else if (src.startsWith('/main')) {
+		if (dest.startsWith('/mtx')) {
+			cmd = MainCommands.MatrixSendOn(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		}
 	}
 	return cmd
 }
 
-export function getSendLevelCommand(sel: string, src: number, dest: number): string {
+export function getSendLevelCommand(src: string, dest: string): string {
 	let cmd = ''
-	if (sel.startsWith('/ch')) {
-		cmd = ChannelCommands.SendLevel(src, dest)
-	} else if (sel.startsWith('/aux')) {
-		cmd = AuxCommands.SendLevel(src, dest)
-	} else if (sel.startsWith('/bus')) {
-		cmd = BusCommands.SendLevel(src, dest)
+	if (src.startsWith('/ch')) {
+		if (dest.startsWith('/bus')) {
+			cmd = ChannelCommands.SendLevel(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		} else if (dest.startsWith('/mtx')) {
+			cmd = ChannelCommands.MatrixSendLevel(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		} else if (dest.startsWith('/main')) {
+			cmd = ChannelCommands.MainSendLevel(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		}
+	} else if (src.startsWith('/aux')) {
+		if (dest.startsWith('/bus')) {
+			cmd = AuxCommands.SendLevel(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		} else if (dest.startsWith('/mtx')) {
+			cmd = AuxCommands.MatrixSendLevel(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		} else if (dest.startsWith('/main')) {
+			cmd = AuxCommands.MainSendLevel(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		}
+	} else if (src.startsWith('/bus')) {
+		if (dest.startsWith('/bus')) {
+			cmd = BusCommands.SendLevel(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		} else if (dest.startsWith('/mtx')) {
+			cmd = BusCommands.MatrixSendLevel(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		} else if (dest.startsWith('/main')) {
+			cmd = BusCommands.MainSendLevel(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		}
+	} else if (src.startsWith('/main')) {
+		if (dest.startsWith('/mtx')) {
+			cmd = MainCommands.MatrixSendLevel(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		}
 	}
 	return cmd
 }
 
-export function getSendPanoramaCommand(sel: string, src: number, dest: number): string {
+export function getSendPanoramaCommand(src: string, dest: string): string {
 	let cmd = ''
-	if (sel.startsWith('/ch')) {
-		cmd = ChannelCommands.SendPan(src, dest)
-	} else if (sel.startsWith('/aux')) {
-		cmd = AuxCommands.SendPan(src, dest)
+	if (src.startsWith('/ch')) {
+		if (dest.startsWith('/bus')) {
+			cmd = ChannelCommands.SendPan(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		} else if (dest.startsWith('/mtx')) {
+			cmd = ChannelCommands.MatrixSendPan(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		}
+	} else if (src.startsWith('/aux')) {
+		if (dest.startsWith('/bus')) {
+			cmd = AuxCommands.SendPan(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		} else if (dest.startsWith('/mtx')) {
+			cmd = AuxCommands.MatrixSendPan(getNodeNumberFromID(src), getNodeNumberFromID(dest))
+		}
 	}
 	return cmd
 }

--- a/src/actions/utils.ts
+++ b/src/actions/utils.ts
@@ -198,7 +198,9 @@ export function getPanoramaCommand(sel: string, val: number): string {
 
 export function getDelayOnCommand(sel: string, val: number): string {
 	let cmd = ''
-	if (sel.startsWith('/bus')) {
+	if (sel.startsWith('/ch')) {
+		cmd = ChannelCommands.DelayOn(val)
+	} else if (sel.startsWith('/bus')) {
 		cmd = BusCommands.DelayOn(val)
 	} else if (sel.startsWith('/mtx')) {
 		cmd = MatrixCommands.DelayOn(val)
@@ -210,7 +212,9 @@ export function getDelayOnCommand(sel: string, val: number): string {
 
 export function getDelayModeCommand(sel: string, val: number): string {
 	let cmd = ''
-	if (sel.startsWith('/bus')) {
+	if (sel.startsWith('/ch')) {
+		cmd = ChannelCommands.DelayMode(val)
+	} else if (sel.startsWith('/bus')) {
 		cmd = BusCommands.DelayMode(val)
 	} else if (sel.startsWith('/mtx')) {
 		cmd = MatrixCommands.DelayMode(val)
@@ -222,7 +226,9 @@ export function getDelayModeCommand(sel: string, val: number): string {
 
 export function getDelayAmountCommand(sel: string, val: number): string {
 	let cmd = ''
-	if (sel.startsWith('/bus')) {
+	if (sel.startsWith('/ch')) {
+		cmd = ChannelCommands.DelayAmount(val)
+	} else if (sel.startsWith('/bus')) {
 		cmd = BusCommands.DelayAmount(val)
 	} else if (sel.startsWith('/mtx')) {
 		cmd = MatrixCommands.DelayAmount(val)

--- a/src/actions/utils.ts
+++ b/src/actions/utils.ts
@@ -327,6 +327,14 @@ export function getTalkbackAssignCommand(talkback: string, destination: string):
 	return cmd
 }
 
+export function getGateEnableCommand(sel: string, val: number): string {
+	let cmd = ''
+	if (sel.startsWith('/ch')) {
+		cmd = ChannelCommands.GateOn(val)
+	}
+	return cmd
+}
+
 export function getEqEnableCommand(sel: string, val: number): string {
 	let cmd = ''
 	if (sel.startsWith('/ch')) {
@@ -339,6 +347,22 @@ export function getEqEnableCommand(sel: string, val: number): string {
 		cmd = MatrixCommands.EqOn(val)
 	} else if (sel.startsWith('/main')) {
 		cmd = MainCommands.EqOn(val)
+	}
+	return cmd
+}
+
+export function getDynamicsEnableCommand(sel: string, val: number): string {
+	let cmd = ''
+	if (sel.startsWith('/ch')) {
+		cmd = ChannelCommands.DynamicsOn(val)
+	} else if (sel.startsWith('/aux')) {
+		cmd = AuxCommands.DynamicsOn(val)
+	} else if (sel.startsWith('/bus')) {
+		cmd = BusCommands.DynamicsOn(val)
+	} else if (sel.startsWith('/mtx')) {
+		cmd = MatrixCommands.DynamicsOn(val)
+	} else if (sel.startsWith('/main')) {
+		cmd = MainCommands.DynamicsOn(val)
 	}
 	return cmd
 }

--- a/src/commands/auxes.ts
+++ b/src/commands/auxes.ts
@@ -156,6 +156,10 @@ export namespace AuxCommands {
 		return `${Node(aux)}/send/MX${mtx}`
 	}
 
+	export function MatrixSendOn(aux: number, mtx: number): string {
+		return `${MatrixSendNode(aux, mtx)}/on`
+	}
+
 	export function MatrixSendLevel(aux: number, mtx: number): string {
 		return `${MatrixSendNode(aux, mtx)}/lvl`
 	}

--- a/src/commands/auxes.ts
+++ b/src/commands/auxes.ts
@@ -171,4 +171,12 @@ export namespace AuxCommands {
 	export function EqOn(aux: number): string {
 		return `${EqNode(aux)}/on`
 	}
+
+	export function DynamicsNode(aux: number): string {
+		return `${Node(aux)}/dyn`
+	}
+
+	export function DynamicsOn(aux: number): string {
+		return `${DynamicsNode(aux)}/on`
+	}
 }

--- a/src/commands/bus.ts
+++ b/src/commands/bus.ts
@@ -140,6 +140,14 @@ export namespace BusCommands {
 		return `${EqNode(bus)}/on`
 	}
 
+	export function DynamicsNode(bus: number): string {
+		return `${Node(bus)}/dyn`
+	}
+
+	export function DynamicsOn(bus: number): string {
+		return `${DynamicsNode(bus)}/on`
+	}
+
 	export function PreInsertNode(bus: number): string {
 		return `${Node(bus)}/preins`
 	}

--- a/src/commands/channel.ts
+++ b/src/commands/channel.ts
@@ -255,6 +255,14 @@ export namespace ChannelCommands {
 		return `${PostInsertNode(channel)}/on`
 	}
 
+	export function GateNode(channel: number): string {
+		return `${Node(channel)}/gate`
+	}
+
+	export function GateOn(channel: number): string {
+		return `${GateNode(channel)}/on`
+	}
+
 	export function EqNode(channel: number): string {
 		return `${Node(channel)}/eq`
 	}
@@ -265,5 +273,13 @@ export namespace ChannelCommands {
 
 	export function EqModel(channel: number): string {
 		return `${EqNode(channel)}/mdl`
+	}
+
+	export function DynamicsNode(channel: number): string {
+		return `${Node(channel)}/dyn`
+	}
+
+	export function DynamicsOn(channel: number): string {
+		return `${DynamicsNode(channel)}/on`
 	}
 }

--- a/src/commands/channel.ts
+++ b/src/commands/channel.ts
@@ -44,12 +44,16 @@ export namespace ChannelCommands {
 		return `${InputSetNode(channel)}/$vph`
 	}
 
-	export function InputDelay(channel: number): string {
-		return `${InputSetNode(channel)}/dly`
+	export function DelayOn(channel: number): string {
+		return `${InputSetNode(channel)}/dlyon`
 	}
 
-	export function InputDelayOn(channel: number): string {
-		return `${InputSetNode(channel)}/dlyon`
+	export function DelayMode(channel: number): string {
+		return `${InputSetNode(channel)}/dlymode`
+	}
+
+	export function DelayAmount(channel: number): string {
+		return `${InputSetNode(channel)}/dly`
 	}
 
 	export function InputConnectionNode(channel: number): string {

--- a/src/commands/main.ts
+++ b/src/commands/main.ts
@@ -80,7 +80,7 @@ export namespace MainCommands {
 		return `${Node(main)}/send/MX${matrix}`
 	}
 
-	export function MatrixSendMute(main: number, matrix: number): string {
+	export function MatrixSendOn(main: number, matrix: number): string {
 		return `${MatrixSendNode(main, matrix)}/on`
 	}
 

--- a/src/commands/main.ts
+++ b/src/commands/main.ts
@@ -116,6 +116,14 @@ export namespace MainCommands {
 		return `${EqNode(main)}/on`
 	}
 
+	export function DynamicsNode(main: number): string {
+		return `${Node(main)}/dyn`
+	}
+
+	export function DynamicsOn(main: number): string {
+		return `${DynamicsNode(main)}/on`
+	}
+
 	export function PreInsertNode(main: number): string {
 		return `${Node(main)}/preins`
 	}

--- a/src/commands/matrix.ts
+++ b/src/commands/matrix.ts
@@ -124,6 +124,14 @@ export namespace MatrixCommands {
 		return `${EqNode(matrix)}/on`
 	}
 
+	export function DynamicsNode(matrix: number): string {
+		return `${Node(matrix)}/dyn`
+	}
+
+	export function DynamicsOn(matrix: number): string {
+		return `${DynamicsNode(matrix)}/on`
+	}
+
 	export function PreInsertNode(matrix: number): string {
 		return `${Node(matrix)}/preins`
 	}


### PR DESCRIPTION
closes #111 

I went through all of the actions and fixed any that didn't have all the channel strip types that were supported. I also unified all the send actions to clean things up a bit. I think after these are merged, we might want to release a v2.0.1