### PR TITLE
Add Support for CC Surfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	"devDependencies": {
 		"@companion-module/tools": "^2.1.1",
 		"@types/node": "^22.10.2",
+		"@types/ws": "^8.18.1",
 		"eslint": "^9.17.0",
 		"husky": "^9.1.7",
 		"lint-staged": "^15.2.11",

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,14 @@ export interface WingConfig {
 	/** When enabled, the module will request values for all variables on startup */
 	prefetchVariablesOnStartup?: boolean
 
+	useCcSurfaces?: boolean
+	showCcTutorial?: boolean
+	useCcUserPages?: boolean
+	ccUserPagesToCreate?: number[]
+	useCcGpio?: boolean
+	useCcUser?: boolean
+	useCcDaw?: boolean
+
 	// Advanced Option
 	requestTimeout?: number
 	panicOnLostRequest?: boolean
@@ -127,6 +135,131 @@ export function GetConfigFields(_self: InstanceBaseExt<WingConfig>): SomeCompani
 			tooltip: 'Request values for all variables when establishing a connection to a desk.',
 			width: 6,
 			default: true,
+		},
+		spacer,
+		{
+			type: 'checkbox',
+			id: 'useCcSurfaces',
+			label: 'Enable Virtual Control Surfaces',
+			tooltip:
+				'Master toggle for Virtual Control surface support. This is an advanced feature - see tutorial below for setup details.',
+			width: 12,
+			default: false,
+		},
+		{
+			type: 'static-text',
+			id: 'cc-surfaces-info',
+			width: 12,
+			label: 'Advanced Feature',
+			value:
+				'Creates virtual Satellite surfaces that respond to Custom Control button presses on your Wing console. ' +
+				"This allows you to trigger Companion actions directly from the console's CC buttons. ",
+			isVisibleExpression: `$(options:useCcSurfaces) == true`,
+		},
+		{
+			type: 'checkbox',
+			id: 'showCcTutorial',
+			label: 'Show Tutorial',
+			tooltip: 'Display detailed setup instructions for Custom Control Surfaces.',
+			width: 12,
+			default: false,
+			isVisibleExpression: `$(options:useCcSurfaces) == true`,
+		},
+		{
+			type: 'static-text',
+			id: 'cc-tutorial',
+			width: 12,
+			label: 'Setup Tutorial',
+			value:
+				'<h3>How It Works</h3>' +
+				'<p>When you press a Custom Control button on your Wing console, the corresponding button press is sent to Companion, where you can program any action you want.</p>' +
+				'<h3>Configuration Steps</h3>' +
+				'<ol>' +
+				'<li><strong>Enable Custom Control Surfaces</strong> - Check the master toggle above</li>' +
+				'<li><strong>Select Surface Types</strong> - Choose which surface types you want to create:' +
+				'<ul>' +
+				'<li><strong>User Pages (CC)</strong> - Creates surfaces for User Pages (U1-U16) with encoders and buttons. You can select specific pages to create (1-16).</li>' +
+				'<li><strong>GPIO Buttons</strong> - Creates a surface for GPIO buttons</li>' +
+				'<li><strong>User Buttons</strong> - Creates a surface for User buttons (8 buttons)</li>' +
+				'<li><strong>DAW Buttons</strong> - Creates surfaces for DAW buttons (4 sets of 8 buttons)</li>' +
+				'</ul>' +
+				'</li>' +
+				"<li><strong>Configure in Companion</strong> - After enabling, the surfaces will appear in Companion's <strong>Surfaces</strong> tab where you can assign them to pages</li>" +
+				'</ol>' +
+				'<h3>Recommended Page Mapping</h3>' +
+				'<p>It is advisable to dedicate one Companion page per Wing User Page surface. This provides a clear one-to-one relationship between your console and Companion.</p>' +
+				'<p><strong>In the Surfaces section:</strong></p>' +
+				'<ul>' +
+				'<li>Assign each surface to a page number with a matching last digit. Deactivate "Use last page at startup" and select the desired page number for "Startup Page" and "Current Page"</li>' +
+				'<li>For example:' +
+				'<ul>' +
+				'<li><code>WING_CC_01</code> → Page 71</li>' +
+				'<li><code>WING_CC_02</code> → Page 72</li>' +
+				'<li><code>WING_CC_03</code> → Page 73</li>' +
+				'<li>And so on...</li>' +
+				'</ul>' +
+				'</li>' +
+				'</ul>' +
+				'<p>This numbering scheme makes it easy to identify which Companion page corresponds to which User Page on your Wing console.</p>' +
+				'<p><strong>In the Buttons section:</strong></p>' +
+				'<ul>' +
+				'<li>Configure the actual button actions for each page (e.g. 71) in the "Buttons" section of Companion</li>' +
+				'</ul>' +
+				'<h3>Requirements</h3>' +
+				'<ul>' +
+				'<li><strong>Important:</strong> On the Wing console, each Custom Control button must have a MIDI command assigned for it to send OSC event updates to Companion. The same MIDI command can be used for all buttons.</li>' +
+				'</ul>',
+			isVisibleExpression: `$(options:useCcSurfaces) == true && $(options:showCcTutorial) == true`,
+		},
+		{
+			type: 'checkbox',
+			id: 'useCcUserPages',
+			label: 'Enable User Pages (CC)',
+			tooltip: 'Create surfaces for User Pages (U1-U16) with encoders and buttons.',
+			width: 6,
+			default: false,
+			isVisibleExpression: `$(options:useCcSurfaces) == true`,
+		},
+		{
+			type: 'multidropdown',
+			id: 'ccUserPagesToCreate',
+			label: 'User Pages to Create',
+			tooltip: 'Select which User Pages (1-16) to create as virtual surfaces.',
+			width: 12,
+			choices: Array.from({ length: 16 }, (_, i) => ({
+				id: i + 1,
+				label: `CC Page ${i + 1}`,
+			})),
+			default: [16],
+			minSelection: 0,
+			isVisibleExpression: `$(options:useCcSurfaces) == true && $(options:useCcUserPages) == true`,
+		},
+		{
+			type: 'checkbox',
+			id: 'useCcGpio',
+			label: 'Enable GPIO Buttons',
+			tooltip: 'Create a virtual surface for GPIO buttons.',
+			width: 6,
+			default: false,
+			isVisibleExpression: `$(options:useCcSurfaces) == true`,
+		},
+		{
+			type: 'checkbox',
+			id: 'useCcUser',
+			label: 'Enable User Buttons',
+			tooltip: 'Create a virtual surface for User buttons (8 buttons).',
+			width: 6,
+			default: false,
+			isVisibleExpression: `$(options:useCcSurfaces) == true`,
+		},
+		{
+			type: 'checkbox',
+			id: 'useCcDaw',
+			label: 'Enable DAW Buttons',
+			tooltip: 'Create virtual surfaces for DAW buttons (4 sets of 8 buttons).',
+			width: 6,
+			default: false,
+			isVisibleExpression: `$(options:useCcSurfaces) == true`,
 		},
 		spacer,
 		{

--- a/src/handlers/cc-handler.ts
+++ b/src/handlers/cc-handler.ts
@@ -1,0 +1,254 @@
+import { OscMessage } from 'osc'
+import osc from 'osc'
+import { ModelSpec } from '../models/types.js'
+import { SatelliteClient } from './satellite-client.js'
+import { ModuleLogger } from './logger.js'
+
+export class CustomControlsHandler {
+	private companion: SatelliteClient
+	private connectionReady: Promise<void>
+	private model: ModelSpec
+	private logger?: ModuleLogger
+
+	// Flags to track which surfaces are enabled
+	private ccPagesEnabled = false
+	private enabledPages: Set<number> = new Set()
+	private gpioEnabled = false
+	private userEnabled = false
+	private dawEnabled = false
+
+	// Pre-compiled regex patterns for OSC message matching
+	private readonly userFullRegex = /^\/\$ctl\/user\/U(\d+)\/(\d+)\/(enc|bu|bd)\/val$/
+	private readonly gpioRegex = /^\/\$ctl\/user\/gpio\/(\d+)\/bu\/val$/
+	private readonly userButtonRegex = /^\/\$ctl\/user\/user\/1\.\.4\/(bu|bd)\/val$/
+	private readonly dawRegex = /^\/\$ctl\/user\/daw(\d+)\.\.daw(\d+)\/1\.\.4\/(bu|bd)\/val$/
+
+	// Row name to number mapping (enc=1, bu=2, bd=3)
+	private readonly rowMap = new Map<string, number>([
+		['bu', 0],
+		['bd', 1],
+		['enc', 2],
+	])
+
+	constructor(model: ModelSpec, logger?: ModuleLogger) {
+		this.model = model
+		this.logger = logger
+		this.companion = new SatelliteClient('localhost', 16623, true)
+		this.connectionReady = this.init()
+	}
+
+	private async init() {
+		await this.companion.connect(2000)
+	}
+
+	/**
+	 * Removes all Wing Custom Control surfaces.
+	 *
+	 * This is not strictly necessary. Removing the surfaces results in the server showing the unused surfaces as disconnected, somewhat improving clarity.
+	 */
+	private removeAllSurfaces(): void {
+		// Remove User Pages
+		for (let i = 1; i <= this.model.userPages; i++) {
+			const pageNumber = i.toString().padStart(2, '0')
+			this.companion.removeSurface(`WING_CC_${pageNumber}`)
+		}
+		this.companion.removeSurface(`WING_GPIO`)
+		this.companion.removeSurface(`WING_USER`)
+		for (let i = 1; i <= 4; i++) {
+			this.companion.removeSurface(`WING_DAW_${i}`)
+		}
+	}
+
+	/**
+	 * Surface creation helper.
+	 *
+	 * @param idBase Base ID for the surface (e.g., 'WING_CC', 'WING_GPIO')
+	 * @param labelBase Base label for the surface (e.g., 'Wing CC', 'Wing GPIO')
+	 * @param rows Number of rows on the surface
+	 * @param columns Number of columns on the surface
+	 * @param suffix Optional suffix for the surface ID and label (e.g., page number, DAW set number)
+	 */
+	private createSurface(idBase: string, labelBase: string, rows: number, columns: number, suffix?: string): void {
+		const suffixPart = suffix ? `_${suffix}` : ''
+		const suffixLabel = suffix ? ` ${suffix}` : ''
+
+		const surfaceId = `${idBase}${suffixPart}`
+		const surfaceLabel = `${labelBase}${suffixLabel}`
+
+		this.companion.addSurface(surfaceId, surfaceLabel, rows, columns)
+	}
+
+	/**
+	 * Creates User Pages (U1-U16) Satellite surfaces.
+	 *
+	 * @param pagesToCreate Array of page numbers (1-16) to create
+	 */
+	async createCcUserPageSurfaces(pagesToCreate: number[]): Promise<void> {
+		await this.connectionReady
+
+		this.enabledPages = new Set(pagesToCreate)
+		console.log('Creating CC User Page surfaces for pages:', pagesToCreate)
+
+		for (const pageNum of pagesToCreate) {
+			if (pageNum >= 1 && pageNum <= this.model.userPages) {
+				const pageNumber = pageNum.toString().padStart(2, '0')
+				this.createSurface('WING_CC', 'Wing CC', this.model.userPageRows, this.model.userPageColumns, pageNumber)
+			}
+		}
+
+		this.ccPagesEnabled = true
+	}
+
+	/**
+	 * Creates GPIO buttons Satellite surface.
+	 */
+	async createCcGpioSurface(): Promise<void> {
+		await this.connectionReady
+
+		this.createSurface('WING_GPIO', 'Wing GPIO', 1, this.model.gpio)
+
+		this.gpioEnabled = true
+	}
+
+	/**
+	 * Creates User buttons Satellite surface.
+	 */
+	async createCcUserSurface(): Promise<void> {
+		await this.connectionReady
+
+		this.createSurface('WING_USER', 'Wing User', 2, 4)
+
+		this.userEnabled = true
+	}
+
+	/**
+	 * Creates DAW buttons Satellite surfaces.
+	 */
+	async createCcDawSurfaces(): Promise<void> {
+		await this.connectionReady
+
+		for (let i = 1; i <= 4; i++) {
+			this.createSurface('WING_DAW', 'Wing DAW', 2, 4, i.toString())
+		}
+
+		this.dawEnabled = true
+	}
+
+	/**
+	 * Sets up Custom Control surfaces based on configuration.
+	 *
+	 * @param config Configuration object with surface type toggles
+	 */
+	async setupSurfaces(config: {
+		useCcUserPages?: boolean
+		ccUserPagesToCreate?: number[]
+		useCcGpio?: boolean
+		useCcUser?: boolean
+		useCcDaw?: boolean
+	}): Promise<void> {
+		await this.connectionReady
+
+		this.removeAllSurfaces()
+		this.ccPagesEnabled = config.useCcUserPages ?? false
+		this.enabledPages.clear()
+		this.gpioEnabled = config.useCcGpio ?? false
+		this.userEnabled = config.useCcUser ?? false
+		this.dawEnabled = config.useCcDaw ?? false
+
+		if (this.ccPagesEnabled) {
+			const pagesToCreate = config.ccUserPagesToCreate ?? []
+			await this.createCcUserPageSurfaces(pagesToCreate)
+		}
+
+		if (this.gpioEnabled) {
+			await this.createCcGpioSurface()
+		}
+
+		if (this.userEnabled) {
+			await this.createCcUserSurface()
+		}
+
+		if (this.dawEnabled) {
+			await this.createCcDawSurfaces()
+		}
+	}
+
+	async processMessage(msg: OscMessage): Promise<void> {
+		const address = msg.address
+		const args = msg.args as osc.MetaArgument[]
+		await this.connectionReady
+
+		const value = args[0]?.value as number
+		if (value === undefined) {
+			return // No value in message
+		}
+
+		if (this.ccPagesEnabled) {
+			const userFullMatch = address.match(this.userFullRegex)
+			if (userFullMatch) {
+				this.logger?.debug('CC User Page message received')
+				const page = parseInt(userFullMatch[1], 10)
+
+				// Check if the page that sent the message is enabled in CC surfaces
+				if (!this.enabledPages.has(page)) {
+					return // Page not enabled, ignore message
+				}
+
+				const column = parseInt(userFullMatch[2], 10) - 1
+				const rowName = userFullMatch[3]
+				const row = this.rowMap.get(rowName)
+
+				if (row === undefined) {
+					return // Unknown row type
+				}
+
+				const deviceId = `WING_CC_${page.toString().padStart(2, '0')}`
+
+				if (rowName === 'enc') {
+					if (value > 0) {
+						this.companion.keyRotateRight(deviceId, row, column)
+					} else if (value < 0) {
+						this.companion.keyRotateLeft(deviceId, row, column)
+					}
+				} else {
+					if (value === 127) {
+						this.companion.buttonPress(deviceId, row, column)
+					} else if (value === 0) {
+						this.companion.buttonRelease(deviceId, row, column)
+					}
+				}
+				return
+			}
+		}
+
+		if (this.gpioEnabled) {
+			const gpioMatch = address.match(this.gpioRegex)
+			if (gpioMatch) {
+				this.logger?.debug('GPIO button message received')
+				// TODO: Implement GPIO button handling
+				return
+			}
+		}
+
+		if (this.userEnabled) {
+			const userButtonMatch = address.match(this.userButtonRegex)
+			if (userButtonMatch) {
+				this.logger?.debug('User button message received')
+				// TODO: Implement user button handling
+				return
+			}
+		}
+
+		if (this.dawEnabled) {
+			const dawMatch = address.match(this.dawRegex)
+			if (dawMatch) {
+				this.logger?.debug('DAW button message received')
+				// TODO: Implement DAW button handling
+				return
+			}
+		}
+
+		// No pattern matched
+		return
+	}
+}

--- a/src/handlers/satellite-client.ts
+++ b/src/handlers/satellite-client.ts
@@ -1,0 +1,204 @@
+// eslint-disable-next-line n/no-extraneous-import
+import WebSocket from 'ws'
+export class SatelliteClient {
+	host: string
+	port: number
+	socket: WebSocket | null = null
+	heartbeatInterval: NodeJS.Timeout | null = null
+	logging: boolean
+
+	constructor(host: string, port: number, logging = false) {
+		this.host = host
+		this.port = port
+		this.logging = logging
+	}
+
+	log(...messages: any[]): void {
+		if (this.logging) {
+			const message = messages.join(' ')
+			if (message.includes('PING')) return
+			if (message.includes('PONG')) return
+			console.log(message)
+		}
+	}
+	/**
+	 * Establishes a WebSocket connection to the satellite server.
+	 *
+	 * Attempts to connect to the server at the specified host and port.
+	 * If the connection is not established within the given timeout (default: 1000ms), the promise is rejected.
+	 * On successful connection, starts a heartbeat interval to send periodic pings.
+	 * If an error occurs during connection, the socket is disconnected and a reconnection attempt is made.
+	 *
+	 * @param timeoutMs - The maximum time in milliseconds to wait for the connection before timing out. Defaults to 1000ms.
+	 * @returns A promise that resolves when the connection is successfully established, or rejects if the connection fails or times out.
+	 */
+	async connect(timeoutMs = 1000): Promise<void> {
+		return new Promise((resolve, reject) => {
+			let settled = false
+			this.socket = new WebSocket(`ws://${this.host}:${this.port}`)
+			const timer = setTimeout(() => {
+				if (!settled) {
+					settled = true
+					reject(new Error('Connection timeout'))
+					this.disconnect()
+				}
+			}, timeoutMs)
+			this.socket.onopen = () => {
+				if (!settled) {
+					settled = true
+					clearTimeout(timer)
+					this.log('Connected to satellite server')
+					// Setup heartbeat to keep the connection alive
+					if (!this.heartbeatInterval) {
+						this.heartbeatInterval = setInterval(() => {
+							this.sendPing()
+						}, 2000)
+					}
+					this.sendPing()
+					resolve()
+				}
+			}
+			this.socket.onerror = (error: { message: any }) => {
+				if (!settled) {
+					settled = true
+					clearTimeout(timer)
+					reject(new Error(`Connection error: ${error.message}`))
+				}
+				this.disconnect()
+			}
+		})
+	}
+
+	disconnect(): void {
+		if (this.socket) {
+			this.sendCommand('QUIT')
+			this.socket.close()
+			this.socket = null
+		}
+		if (this.heartbeatInterval) {
+			clearInterval(this.heartbeatInterval)
+			this.heartbeatInterval = null
+		}
+	}
+
+	/**
+	 * Sends a command to the connected WebSocket server.
+	 *
+	 * Constructs a message by combining the provided command and optional arguments,
+	 * then sends it over the WebSocket connection if it is open. If no arguments are
+	 * provided, an empty string is used.
+	 *
+	 * @param command - The command string to send.
+	 * @param args - Optional arguments to append to the command.
+	 */
+	sendCommand(command: string, args?: string): void {
+		if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+			if (!args) {
+				args = ''
+			}
+			const message = `${command} ${args}\n`
+			// this.log('Sending:', message)
+			this.socket.send(message)
+		}
+	}
+	sendPing(): void {
+		this.sendCommand('PING')
+	}
+	/**
+	 * Add a new Satellite surface to the Server.
+	 *
+	 * @param deviceId - The unique identifier for the device.
+	 * @param surfaceName - The name of the surface to add.
+	 * @param rows - (Optional) The number of rows on the surface. Used to calculate total keys.
+	 * @param columns - (Optional) The number of columns on the surface. Used to calculate total keys.
+	 *
+	 * Sends an 'ADD-DEVICE' command with the constructed arguments to the device.
+	 */
+	addSurface(deviceId: string, surfaceName: string, rows?: number, columns?: number): void {
+		const keys_total = rows && columns ? rows * columns : 0
+		// eslint-disable-next-line no-useless-escape
+		let args = `DEVICEID=${deviceId} PRODUCT_NAME=\"${surfaceName}\"`
+		if (keys_total > 0) {
+			args += ` KEYS_TOTAL=${keys_total}`
+			args += ` KEYS_PER_ROW=${columns}`
+		}
+		args += ` BRIGHTNESS=false`
+		this.sendCommand('ADD-DEVICE', args)
+	}
+	/**
+	 * Removes a surface device from the system by its device ID.
+	 *
+	 * ATTENTION: This will only remove the Satellite registration of the surface. The surface itself
+	 * will still exist on the Server.
+	 *
+	 * Sends a 'REMOVE-DEVICE' command with the specified device ID as an argument.
+	 *
+	 * @param deviceId - The unique identifier of the device to be removed.
+	 */
+	removeSurface(deviceId: string): void {
+		const args = `DEVICEID=${deviceId}`
+		this.sendCommand('REMOVE-DEVICE', args)
+	}
+	/**
+	 * Presses a button on a specified device surface.
+	 *
+	 * The button is indexed by its row and column on the surface from top left (0/0) to bottom right.
+	 */
+	buttonPressRelease(deviceId: string, row: number, column: number): void {
+		this.buttonPress(deviceId, row, column)
+		this.buttonRelease(deviceId, row, column)
+	}
+
+	/**
+	 * Sends a button press event for a specified button.
+	 *
+	 * @param page - The page number.
+	 * @param row - The row number.
+	 * @param column - The column number.
+	 */
+	buttonPress(deviceId: string, row: number, column: number): void {
+		const COMMAND = 'KEY-PRESS'
+		const args = `DEVICEID=${deviceId} KEY=${row}/${column}`
+		this.sendCommand(COMMAND, args + ' PRESSED=1')
+	}
+
+	/**
+	 * Sends a button release event for a specified button.
+	 *
+	 * @param deviceId - The device identifier.
+	 * @param row - The row number.
+	 * @param column - The column number.
+	 */
+	buttonRelease(deviceId: string, row: number, column: number): void {
+		const COMMAND = 'KEY-PRESS'
+		const args = `DEVICEID=${deviceId} KEY=${row}/${column}`
+		this.sendCommand(COMMAND, args + ' PRESSED=0')
+	}
+
+	/**
+	 * Sends a key rotate left event for a specified encoder.
+	 *
+	 * @param deviceId - The device identifier.
+	 * @param row - The row number.
+	 * @param column - The column number.
+	 */
+	keyRotateLeft(deviceId: string, row: number, column: number): void {
+		const COMMAND = 'KEY-ROTATE'
+		const args = `DEVICEID=${deviceId} KEY=${row}/${column} DIRECTION=-1`
+		this.sendCommand(COMMAND, args)
+	}
+
+	/**
+	 * Sends a key rotate right event for a specified encoder.
+	 *
+	 * @param deviceId - The device identifier.
+	 * @param row - The row number.
+	 * @param column - The column number.
+	 */
+	keyRotateRight(deviceId: string, row: number, column: number): void {
+		const COMMAND = 'KEY-ROTATE'
+		const args = `DEVICEID=${deviceId} KEY=${row}/${column} DIRECTION=1`
+		this.sendCommand(COMMAND, args)
+	}
+}
+//# sourceMappingURL=satellite-client.js.map

--- a/src/models/compact.ts
+++ b/src/models/compact.ts
@@ -20,4 +20,8 @@ export const WingCompact: ModelSpec = {
 	aesOut: 2,
 	stageConnect: 1,
 	gpio: 2,
+
+	userPages: 16,
+	userPageRows: 2,
+	userPageColumns: 2,
 }

--- a/src/models/full.ts
+++ b/src/models/full.ts
@@ -20,4 +20,8 @@ export const WingFull: ModelSpec = {
 	aesOut: 2,
 	stageConnect: 1,
 	gpio: 4,
+
+	userPages: 16,
+	userPageRows: 3,
+	userPageColumns: 4,
 }

--- a/src/models/rack.ts
+++ b/src/models/rack.ts
@@ -20,4 +20,8 @@ export const WingRack: ModelSpec = {
 	aesOut: 2,
 	stageConnect: 1,
 	gpio: 4,
+
+	userPages: 16,
+	userPageRows: 3,
+	userPageColumns: 4,
 }

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -28,6 +28,10 @@ export interface ModelSpec {
 	stageConnect: number
 	headphoneOuts?: number
 	gpio: number
+
+	userPages: number
+	userPageRows: number
+	userPageColumns: number
 }
 
 export const ModelChoices: DropdownChoice[] = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,8 +6,8 @@ __metadata:
   cacheKey: 10c0
 
 "@companion-module/base@npm:~1.13":
-  version: 1.13.5
-  resolution: "@companion-module/base@npm:1.13.5"
+  version: 1.13.6
+  resolution: "@companion-module/base@npm:1.13.6"
   dependencies:
     ajv: "npm:^8.17.1"
     colord: "npm:^2.9.3"
@@ -18,31 +18,36 @@ __metadata:
     p-queue: "npm:^6.6.2"
     p-timeout: "npm:^4.1.0"
     tslib: "npm:^2.8.1"
-  checksum: 10c0/cb88a1a57a1aa1c60b4198bc055446ec8184a16bd724c39596bd112b309bd570af120462f1642146d363abfbe62ca9adad07c9cfc2eb2a875693413b8e308956
+  checksum: 10c0/213e331bd0ae1611d7677a7eb216bbbc80df2931bb092a1e989c592702943685616d53bf240812a82fb5390cc7cfda16ee38d2982347743e3862fc2317b711f5
   languageName: node
   linkType: hard
 
 "@companion-module/tools@npm:^2.1.1":
-  version: 2.4.2
-  resolution: "@companion-module/tools@npm:2.4.2"
+  version: 2.5.0
+  resolution: "@companion-module/tools@npm:2.5.0"
   dependencies:
-    "@eslint/js": "npm:^9.36.0"
+    "@eslint/js": "npm:^9.39.2"
     eslint-config-prettier: "npm:^10.1.8"
     eslint-plugin-n: "npm:^17.23.1"
     eslint-plugin-prettier: "npm:^5.5.4"
     find-up: "npm:^7.0.0"
     parse-author: "npm:^2.0.0"
-    semver: "npm:^7.7.2"
-    tar: "npm:^7.5.1"
-    webpack: "npm:^5.101.3"
+    semver: "npm:^7.7.3"
+    tar: "npm:^7.5.2"
+    webpack: "npm:^5.103.0"
     webpack-cli: "npm:^6.0.1"
-    zx: "npm:^8.8.4"
+    zx: "npm:^8.8.5"
   peerDependencies:
     "@companion-module/base": ^1.12.0
+    "@companion-surface/base": ^1.0.0
     eslint: ^9.36.0
     prettier: ^3.6.2
     typescript-eslint: ^8.44.1
   peerDependenciesMeta:
+    "@companion-module/base":
+      optional: true
+    "@companion-surface/base":
+      optional: true
     eslint:
       optional: true
     prettier:
@@ -50,10 +55,12 @@ __metadata:
     typescript-eslint:
       optional: true
   bin:
-    companion-generate-manifest: scripts/generate-manifest.js
-    companion-module-build: scripts/build.js
-    companion-module-check: scripts/check.js
-  checksum: 10c0/b4684c50dba38c12fc666e3b3f56b8723330dc8c21688b19d10bf1a5fb367a907dc7a02c8c14a7f3ae3a0fda902a7b09145c05daca771c8db61892e4c76cccee
+    companion-generate-manifest: scripts/generate-connection-manifest.js
+    companion-module-build: scripts/build-connection.js
+    companion-module-check: scripts/check-connection.js
+    companion-surface-build: scripts/build-surface.js
+    companion-surface-check: scripts/check-surface.js
+  checksum: 10c0/5c8d6eb1ba2b2839e055c4277770d62ebc9fe66ca420f72762bfb8283d319bb32335f0187e79d04a0817f1a7a6baa19f522a2dbb33d99fa3a47d502c8e541a9c
   languageName: node
   linkType: hard
 
@@ -128,10 +135,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.39.1, @eslint/js@npm:^9.36.0":
-  version: 9.39.1
-  resolution: "@eslint/js@npm:9.39.1"
-  checksum: 10c0/6f7f26f8cdb7ad6327bbf9741973b6278eb946f18f70e35406e88194b0d5c522d0547a34a02f2a208eec95c5d1388cdf7ccb20039efd2e4cb6655615247a50f1
+"@eslint/js@npm:9.39.2, @eslint/js@npm:^9.39.2":
+  version: 9.39.2
+  resolution: "@eslint/js@npm:9.39.2"
+  checksum: 10c0/00f51c52b04ac79faebfaa65a9652b2093b9c924e945479f1f3945473f78aee83cbc76c8d70bbffbf06f7024626575b16d97b66eab16182e1d0d39daff2f26f5
   languageName: node
   linkType: hard
 
@@ -445,156 +452,164 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 24.10.1
-  resolution: "@types/node@npm:24.10.1"
+  version: 25.0.3
+  resolution: "@types/node@npm:25.0.3"
   dependencies:
     undici-types: "npm:~7.16.0"
-  checksum: 10c0/d6bca7a78f550fbb376f236f92b405d676003a8a09a1b411f55920ef34286ee3ee51f566203920e835478784df52662b5b2af89159d9d319352e9ea21801c002
+  checksum: 10c0/b7568f0d765d9469621615e2bb257c7fd1953d95e9acbdb58dffb6627a2c4150d405a4600aa1ad8a40182a94fe5f903cafd3c0a2f5132814debd0e3bfd61f835
   languageName: node
   linkType: hard
 
 "@types/node@npm:^22.10.2":
-  version: 22.19.1
-  resolution: "@types/node@npm:22.19.1"
+  version: 22.19.3
+  resolution: "@types/node@npm:22.19.3"
   dependencies:
     undici-types: "npm:~6.21.0"
-  checksum: 10c0/6edd93aea86da740cb7872626839cd6f4a67a049d3a3a6639cb592c620ec591408a30989ab7410008d1a0b2d4985ce50f1e488e79c033e4476d3bec6833b0a2f
+  checksum: 10c0/a30a75d503da795ddbd5f8851014f3e91925c2a63fa3f14128d54c998f25d682dfba96dc9589c73cf478b87a16d88beb790b11697bb8cd5bee913079237a58f2
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.48.1":
-  version: 8.48.1
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.48.1"
+"@types/ws@npm:^8.18.1":
+  version: 8.18.1
+  resolution: "@types/ws@npm:8.18.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/61aff1129143fcc4312f083bc9e9e168aa3026b7dd6e70796276dcfb2c8211c4292603f9c4864fae702f2ed86e4abd4d38aa421831c2fd7f856c931a481afbab
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/eslint-plugin@npm:8.51.0":
+  version: 8.51.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.51.0"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.48.1"
-    "@typescript-eslint/type-utils": "npm:8.48.1"
-    "@typescript-eslint/utils": "npm:8.48.1"
-    "@typescript-eslint/visitor-keys": "npm:8.48.1"
-    graphemer: "npm:^1.4.0"
+    "@typescript-eslint/scope-manager": "npm:8.51.0"
+    "@typescript-eslint/type-utils": "npm:8.51.0"
+    "@typescript-eslint/utils": "npm:8.51.0"
+    "@typescript-eslint/visitor-keys": "npm:8.51.0"
     ignore: "npm:^7.0.0"
     natural-compare: "npm:^1.4.0"
-    ts-api-utils: "npm:^2.1.0"
+    ts-api-utils: "npm:^2.2.0"
   peerDependencies:
-    "@typescript-eslint/parser": ^8.48.1
+    "@typescript-eslint/parser": ^8.51.0
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/aeb4692ac27ded73dce5ddba08d46f15d617651f629cdfc5e874dd4ac767eac0523807f1f4e51f6f80675efff78e5937690f1c58740b8cb92b44b87d757a6a1a
+  checksum: 10c0/3140e66a0f722338d56bf3de2b7cbb9a74a812d8da90fc61975ea029f6a401252c0824063d4c4baab9827de6f0209b34f4bbdc46e3f5fefd8fa2ff4a3980406f
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.48.1":
-  version: 8.48.1
-  resolution: "@typescript-eslint/parser@npm:8.48.1"
+"@typescript-eslint/parser@npm:8.51.0":
+  version: 8.51.0
+  resolution: "@typescript-eslint/parser@npm:8.51.0"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.48.1"
-    "@typescript-eslint/types": "npm:8.48.1"
-    "@typescript-eslint/typescript-estree": "npm:8.48.1"
-    "@typescript-eslint/visitor-keys": "npm:8.48.1"
+    "@typescript-eslint/scope-manager": "npm:8.51.0"
+    "@typescript-eslint/types": "npm:8.51.0"
+    "@typescript-eslint/typescript-estree": "npm:8.51.0"
+    "@typescript-eslint/visitor-keys": "npm:8.51.0"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/54ec22c82cc631f56131bfed9747f8cadf52ab123463a406c5221f258f9533431c4a33ebe21ef178840d50235e69bb370d36aa2fd6a066e7223b38bfa41a1788
+  checksum: 10c0/b6aab1d82cc98a77aaae7637bf2934980104799793b3fd5b893065d930fe9b23cd6c2059d6f73fb454ea08f9e956e84fa940310d8435092a14be645a42062d94
   languageName: node
   linkType: hard
 
-"@typescript-eslint/project-service@npm:8.48.1":
-  version: 8.48.1
-  resolution: "@typescript-eslint/project-service@npm:8.48.1"
+"@typescript-eslint/project-service@npm:8.51.0":
+  version: 8.51.0
+  resolution: "@typescript-eslint/project-service@npm:8.51.0"
   dependencies:
-    "@typescript-eslint/tsconfig-utils": "npm:^8.48.1"
-    "@typescript-eslint/types": "npm:^8.48.1"
+    "@typescript-eslint/tsconfig-utils": "npm:^8.51.0"
+    "@typescript-eslint/types": "npm:^8.51.0"
     debug: "npm:^4.3.4"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/0aeeea5e65d0f837bd9a47265f144f14ca72969d259ee929e63e06526b21f4e990e70c7bafdb2ceb3783373df7d9f5bae32c328a4c6403606f01339bc984b3f5
+  checksum: 10c0/c6e6efbf79e126261e1742990b0872a34bbbe9931d99f0aabd12cb70a65a361e02d626db4b632dabee2b2c26b7e5b48344fc5a796c56438ae0788535e2bbe092
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.48.1":
-  version: 8.48.1
-  resolution: "@typescript-eslint/scope-manager@npm:8.48.1"
+"@typescript-eslint/scope-manager@npm:8.51.0":
+  version: 8.51.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.51.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.48.1"
-    "@typescript-eslint/visitor-keys": "npm:8.48.1"
-  checksum: 10c0/16514823784cb598817b87d3d2b4fb618ab8b2378b3401a4c1160a5c914e51e7a925c3c1e7be73e0250e38390f0be70fecb3e0e0bdde7b243d74444933b95d3e
+    "@typescript-eslint/types": "npm:8.51.0"
+    "@typescript-eslint/visitor-keys": "npm:8.51.0"
+  checksum: 10c0/dd1e75fc13e6b1119954612d9e8ad3f2d91bc37dcde85fd00e959171aaf6c716c4c265c90c5accf24b5831bd3f48510b0775e5583085b8fa2ad5c37c8980ae1a
   languageName: node
   linkType: hard
 
-"@typescript-eslint/tsconfig-utils@npm:8.48.1, @typescript-eslint/tsconfig-utils@npm:^8.48.1":
-  version: 8.48.1
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.48.1"
+"@typescript-eslint/tsconfig-utils@npm:8.51.0, @typescript-eslint/tsconfig-utils@npm:^8.51.0":
+  version: 8.51.0
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.51.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/0d540f7ab3018ed1bab8f008c0d30229e0ea12806fdbf1c756572b5cf536a1f2a6c59ca2544c09bcd5b89dcfcf79e5f6be3d765e725492b9c7e4cd64fcecffc6
+  checksum: 10c0/46cab9a5342b4a8f8a1d05aaee4236c5262a540ad0bca1f0e8dad5d63ed1e634b88ce0c82a612976dab09861e21086fc995a368df0435ac43fb960e0b9e5cde2
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.48.1":
-  version: 8.48.1
-  resolution: "@typescript-eslint/type-utils@npm:8.48.1"
+"@typescript-eslint/type-utils@npm:8.51.0":
+  version: 8.51.0
+  resolution: "@typescript-eslint/type-utils@npm:8.51.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.48.1"
-    "@typescript-eslint/typescript-estree": "npm:8.48.1"
-    "@typescript-eslint/utils": "npm:8.48.1"
+    "@typescript-eslint/types": "npm:8.51.0"
+    "@typescript-eslint/typescript-estree": "npm:8.51.0"
+    "@typescript-eslint/utils": "npm:8.51.0"
     debug: "npm:^4.3.4"
-    ts-api-utils: "npm:^2.1.0"
+    ts-api-utils: "npm:^2.2.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/c98a71f7d374be249ecc7c9f20b0a867a73ad4f64e646a6bf9f2c1a5d74f0dc7bd59e9c94a0842068caa366af39ae0c550ede6d653b5c9418a0a587510bbb6d5
+  checksum: 10c0/7c17214e54bc3a4fe4551d9251ffbac52e84ca46eeae840c0f981994b7cbcc837ef32a2b6d510b02d958a8f568df355e724d9c6938a206716271a1b0c00801b7
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.48.1, @typescript-eslint/types@npm:^8.48.1":
-  version: 8.48.1
-  resolution: "@typescript-eslint/types@npm:8.48.1"
-  checksum: 10c0/366b8140f4c69319f1796b66b33c0c6e16eb6cbe543b9517003104e12ed143b620c1433ccf60d781a629d9433bd509a363c0c9d21fd438c17bb8840733af6caa
+"@typescript-eslint/types@npm:8.51.0, @typescript-eslint/types@npm:^8.51.0":
+  version: 8.51.0
+  resolution: "@typescript-eslint/types@npm:8.51.0"
+  checksum: 10c0/eb3473d0bb71eb886438f35887b620ffadae7853b281752a40c73158aee644d136adeb82549be7d7c30f346fe888b2e979dff7e30e67b35377e8281018034529
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.48.1":
-  version: 8.48.1
-  resolution: "@typescript-eslint/typescript-estree@npm:8.48.1"
+"@typescript-eslint/typescript-estree@npm:8.51.0":
+  version: 8.51.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.51.0"
   dependencies:
-    "@typescript-eslint/project-service": "npm:8.48.1"
-    "@typescript-eslint/tsconfig-utils": "npm:8.48.1"
-    "@typescript-eslint/types": "npm:8.48.1"
-    "@typescript-eslint/visitor-keys": "npm:8.48.1"
+    "@typescript-eslint/project-service": "npm:8.51.0"
+    "@typescript-eslint/tsconfig-utils": "npm:8.51.0"
+    "@typescript-eslint/types": "npm:8.51.0"
+    "@typescript-eslint/visitor-keys": "npm:8.51.0"
     debug: "npm:^4.3.4"
     minimatch: "npm:^9.0.4"
     semver: "npm:^7.6.0"
     tinyglobby: "npm:^0.2.15"
-    ts-api-utils: "npm:^2.1.0"
+    ts-api-utils: "npm:^2.2.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/72c0802f74222160f6a13ebbd32b0d504142a2427678c87ea78fc32672c65fd522377d43b31a97c944cbd0aefc36b320bf02f04e47c44f2797d6ccd0a8aa30ec
+  checksum: 10c0/5386acc67298a6757681b6264c29a6b9304be7a188f11498bbaa82bb0a3095fd79394ad80d6520bdff3fa3093199f9a438246604ee3281b76f7ed574b7516854
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.48.1":
-  version: 8.48.1
-  resolution: "@typescript-eslint/utils@npm:8.48.1"
+"@typescript-eslint/utils@npm:8.51.0":
+  version: 8.51.0
+  resolution: "@typescript-eslint/utils@npm:8.51.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.7.0"
-    "@typescript-eslint/scope-manager": "npm:8.48.1"
-    "@typescript-eslint/types": "npm:8.48.1"
-    "@typescript-eslint/typescript-estree": "npm:8.48.1"
+    "@typescript-eslint/scope-manager": "npm:8.51.0"
+    "@typescript-eslint/types": "npm:8.51.0"
+    "@typescript-eslint/typescript-estree": "npm:8.51.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/1775ac217b578f52d6c1e85258098f8ef764d04830c6ce11043b434860da80f1a5f7cc1b9f2e0a63de161e83b8d876f7ae8362d7644d5d8e636e60ad5eeff4e2
+  checksum: 10c0/ffb8237cfb33a1998ae2812b136d42fb65e7497f185d46097d19e43112e41b3ef59f901ba679c2e5372ad3007026f6e5add3a3de0f2e75ce6896918713fa38a8
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.48.1":
-  version: 8.48.1
-  resolution: "@typescript-eslint/visitor-keys@npm:8.48.1"
+"@typescript-eslint/visitor-keys@npm:8.51.0":
+  version: 8.51.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.51.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.48.1"
+    "@typescript-eslint/types": "npm:8.51.0"
     eslint-visitor-keys: "npm:^4.2.1"
-  checksum: 10c0/ecf4078ce63c296dd340672b516f42bf452534c75af7e7d6c1a3f32b143ff184cb3a4071d7429a9f870371ff9091a790acce28b85ce3c450bfc60554c79d43ca
+  checksum: 10c0/fce5603961cf336e71095f7599157de65e3182f61cbd6cab33a43551ee91485b4e9bf6cacc1b275cf6f3503b92f8568fe2267a45c82e60e386ee73db727a26ca
   languageName: node
   linkType: hard
 
@@ -940,11 +955,11 @@ __metadata:
   linkType: hard
 
 "baseline-browser-mapping@npm:^2.9.0":
-  version: 2.9.0
-  resolution: "baseline-browser-mapping@npm:2.9.0"
+  version: 2.9.11
+  resolution: "baseline-browser-mapping@npm:2.9.11"
   bin:
     baseline-browser-mapping: dist/cli.js
-  checksum: 10c0/cc2c4beaaa6310e57d55c0b38767b7d833cad17779a51bd2f1db7c8fb50d86629fa065cf65b9333bbe1d909270a084bd2177f0fbc832633b273504a8c805ab9c
+  checksum: 10c0/eba49fcc1b33ab994aeeb73a4848f2670e06a0886dd5b903689ae6f60d47e7f1bea9262dbb2548c48179e858f7eda2b82ddf941ae783b862f4dcc51085a246f2
   languageName: node
   linkType: hard
 
@@ -976,7 +991,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.26.3":
+"browserslist@npm:^4.28.1":
   version: 4.28.1
   resolution: "browserslist@npm:4.28.1"
   dependencies:
@@ -1025,9 +1040,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001759":
-  version: 1.0.30001759
-  resolution: "caniuse-lite@npm:1.0.30001759"
-  checksum: 10c0/b0f415960ba34995cda18e0d25c4e602f6917b9179290a76bdd0311423505b78cc93e558a90c98a22a1cc6b1781ab720ef6beea24ec7e29a1c1164ca72eac3a2
+  version: 1.0.30001761
+  resolution: "caniuse-lite@npm:1.0.30001761"
+  checksum: 10c0/8ea4158ccd507b9c73c03b9b3b1b897e75d095c5753a131d0f36ef9b64c19a049174467842dd9e8bebe886ac27ed7a5b1d5adcaae5fe887716b07fc1103e100b
   languageName: node
   linkType: hard
 
@@ -1209,9 +1224,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.263":
-  version: 1.5.264
-  resolution: "electron-to-chromium@npm:1.5.264"
-  checksum: 10c0/d62cfc6ed02856de59b0e7baf5bb7995b611ba4df14355a0943301a56628bd0fad98287c0becdcf55509ff5ed38d7f01a33b9f962820c8aa8cbc90292035275c
+  version: 1.5.267
+  resolution: "electron-to-chromium@npm:1.5.267"
+  checksum: 10c0/0732bdb891b657f2e43266a3db8cf86fff6cecdcc8d693a92beff214e136cb5c2ee7dc5945ed75fa1db16e16bad0c38695527a020d15f39e79084e0b2e447621
   languageName: node
   linkType: hard
 
@@ -1231,13 +1246,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.17.1, enhanced-resolve@npm:^5.17.3":
-  version: 5.18.3
-  resolution: "enhanced-resolve@npm:5.18.3"
+"enhanced-resolve@npm:^5.17.1, enhanced-resolve@npm:^5.17.4":
+  version: 5.18.4
+  resolution: "enhanced-resolve@npm:5.18.4"
   dependencies:
     graceful-fs: "npm:^4.2.4"
     tapable: "npm:^2.2.0"
-  checksum: 10c0/d413c23c2d494e4c1c9c9ac7d60b812083dc6d446699ed495e69c920988af0a3c66bf3f8d0e7a45cb1686c2d4c1df9f4e7352d973f5b56fe63d8d711dd0ccc54
+  checksum: 10c0/8f6d42c8a0787a746c493e724c9de5d091cfe8e3f871f2464e2f78a6c55fa1a3aaba495334f923c8ea3ac23e1472491f79feef6fc0fb46a75169cb447ffbe2dc
   languageName: node
   linkType: hard
 
@@ -1271,10 +1286,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-module-lexer@npm:^1.2.1":
-  version: 1.7.0
-  resolution: "es-module-lexer@npm:1.7.0"
-  checksum: 10c0/4c935affcbfeba7fb4533e1da10fa8568043df1e3574b869385980de9e2d475ddc36769891936dbb07036edb3c3786a8b78ccf44964cd130dedc1f2c984b6c7b
+"es-module-lexer@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "es-module-lexer@npm:2.0.0"
+  checksum: 10c0/ae78dbbd43035a4b972c46cfb6877e374ea290adfc62bc2f5a083fea242c0b2baaab25c5886af86be55f092f4a326741cb94334cd3c478c383fdc8a9ec5ff817
   languageName: node
   linkType: hard
 
@@ -1401,8 +1416,8 @@ __metadata:
   linkType: hard
 
 "eslint@npm:^9.17.0":
-  version: 9.39.1
-  resolution: "eslint@npm:9.39.1"
+  version: 9.39.2
+  resolution: "eslint@npm:9.39.2"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.8.0"
     "@eslint-community/regexpp": "npm:^4.12.1"
@@ -1410,7 +1425,7 @@ __metadata:
     "@eslint/config-helpers": "npm:^0.4.2"
     "@eslint/core": "npm:^0.17.0"
     "@eslint/eslintrc": "npm:^3.3.1"
-    "@eslint/js": "npm:9.39.1"
+    "@eslint/js": "npm:9.39.2"
     "@eslint/plugin-kit": "npm:^0.4.1"
     "@humanfs/node": "npm:^0.16.6"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
@@ -1445,7 +1460,7 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10c0/59b2480639404ba24578ca480f973683b87b7aac8aa7e349240474a39067804fd13cd8b9cb22fee074170b8c7c563b57bab703ec0f0d3f81ea017e5d2cad299d
+  checksum: 10c0/bb88ca8fd16bb7e1ac3e13804c54d41c583214460c0faa7b3e7c574e69c5600c7122295500fb4b0c06067831111db740931e98da1340329527658e1cf80073d3
   languageName: node
   linkType: hard
 
@@ -1764,13 +1779,6 @@ __metadata:
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
-  languageName: node
-  linkType: hard
-
-"graphemer@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "graphemer@npm:1.4.0"
-  checksum: 10c0/e951259d8cd2e0d196c72ec711add7115d42eb9a8146c8eeda5b8d3ac91e5dd816b9cd68920726d9fd4490368e7ed86e9c423f40db87e2d8dfafa00fa17c3a31
   languageName: node
   linkType: hard
 
@@ -2746,11 +2754,11 @@ __metadata:
   linkType: hard
 
 "prettier-linter-helpers@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "prettier-linter-helpers@npm:1.0.0"
+  version: 1.0.1
+  resolution: "prettier-linter-helpers@npm:1.0.1"
   dependencies:
     fast-diff: "npm:^1.1.2"
-  checksum: 10c0/81e0027d731b7b3697ccd2129470ed9913ecb111e4ec175a12f0fcfab0096516373bf0af2fef132af50cafb0a905b74ff57996d615f59512bb9ac7378fcc64ab
+  checksum: 10c0/91cea965681bc5f62c9d26bd3ca6358b81557261d4802e96ec1cf0acbd99d4b61632d53320cd2c3ec7d7f7805a81345644108a41ef46ddc9688e783a9ac792d1
   languageName: node
   linkType: hard
 
@@ -2930,7 +2938,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.3, semver@npm:^7.7.2":
+"semver@npm:^7.3.5, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.3, semver@npm:^7.7.3":
   version: 7.7.3
   resolution: "semver@npm:7.7.3"
   bin:
@@ -3165,7 +3173,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.1, tar@npm:^7.5.2":
+"tar@npm:^7.5.2":
   version: 7.5.2
   resolution: "tar@npm:7.5.2"
   dependencies:
@@ -3178,9 +3186,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser-webpack-plugin@npm:^5.3.11":
-  version: 5.3.14
-  resolution: "terser-webpack-plugin@npm:5.3.14"
+"terser-webpack-plugin@npm:^5.3.16":
+  version: 5.3.16
+  resolution: "terser-webpack-plugin@npm:5.3.16"
   dependencies:
     "@jridgewell/trace-mapping": "npm:^0.3.25"
     jest-worker: "npm:^27.4.5"
@@ -3196,7 +3204,7 @@ __metadata:
       optional: true
     uglify-js:
       optional: true
-  checksum: 10c0/9b060947241af43bd6fd728456f60e646186aef492163672a35ad49be6fbc7f63b54a7356c3f6ff40a8f83f00a977edc26f044b8e106cc611c053c8c0eaf8569
+  checksum: 10c0/39e37c5b3015c1a5354a3633f77235677bfa06eac2608ce26d258b1d1a74070a99910319a6f2f2c437eb61dc321f66434febe01d78e73fa96b4d4393b813f4cf
   languageName: node
   linkType: hard
 
@@ -3233,12 +3241,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-api-utils@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "ts-api-utils@npm:2.1.0"
+"ts-api-utils@npm:^2.2.0":
+  version: 2.3.0
+  resolution: "ts-api-utils@npm:2.3.0"
   peerDependencies:
     typescript: ">=4.8.4"
-  checksum: 10c0/9806a38adea2db0f6aa217ccc6bc9c391ddba338a9fe3080676d0d50ed806d305bb90e8cef0276e793d28c8a929f400abb184ddd7ff83a416959c0f4d2ce754f
+  checksum: 10c0/9f2aadb8ac55926c79db03e37ee3b014135923d1705f6868b9e787e6b8822d2fd8e19df2f9002563f4e6268c994425ddaad61df24d0dad833a4be9f26f789213
   languageName: node
   linkType: hard
 
@@ -3277,17 +3285,17 @@ __metadata:
   linkType: hard
 
 "typescript-eslint@npm:^8.18.1":
-  version: 8.48.1
-  resolution: "typescript-eslint@npm:8.48.1"
+  version: 8.51.0
+  resolution: "typescript-eslint@npm:8.51.0"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.48.1"
-    "@typescript-eslint/parser": "npm:8.48.1"
-    "@typescript-eslint/typescript-estree": "npm:8.48.1"
-    "@typescript-eslint/utils": "npm:8.48.1"
+    "@typescript-eslint/eslint-plugin": "npm:8.51.0"
+    "@typescript-eslint/parser": "npm:8.51.0"
+    "@typescript-eslint/typescript-estree": "npm:8.51.0"
+    "@typescript-eslint/utils": "npm:8.51.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/10b501bf69b14edd09d652b33e4a5dfad0498f2943992a433006933e384cdc5815217b2990801796ddf946d2ef4971d9a16c98c7cfbba41f6aa31b245ad057ac
+  checksum: 10c0/ae26e783e7c2e1e2b20c278e5d743fc9aa0ea0ce3c3c06c53f7b0913617ec75d40cb8732fec85e95071e87a5a90fa0867e2c3a11d7b8fec986c55460cc652b47
   languageName: node
   linkType: hard
 
@@ -3351,8 +3359,8 @@ __metadata:
   linkType: hard
 
 "update-browserslist-db@npm:^1.2.0":
-  version: 1.2.1
-  resolution: "update-browserslist-db@npm:1.2.1"
+  version: 1.2.3
+  resolution: "update-browserslist-db@npm:1.2.3"
   dependencies:
     escalade: "npm:^3.2.0"
     picocolors: "npm:^1.1.1"
@@ -3360,7 +3368,7 @@ __metadata:
     browserslist: ">= 4.21.0"
   bin:
     update-browserslist-db: cli.js
-  checksum: 10c0/cbf7547651dfefd2924a61338ccf99cad15ab10bc52ada3fdc3fb1eade14e3cb27a247e6715c3bd2e8941f2bdd322348edfbee8536fff3828188445960b8e490
+  checksum: 10c0/13a00355ea822388f68af57410ce3255941d5fb9b7c49342c4709a07c9f230bbef7f7499ae0ca7e0de532e79a82cc0c4edbd125f1a323a1845bf914efddf8bec
   languageName: node
   linkType: hard
 
@@ -3374,12 +3382,12 @@ __metadata:
   linkType: hard
 
 "watchpack@npm:^2.4.4":
-  version: 2.4.4
-  resolution: "watchpack@npm:2.4.4"
+  version: 2.5.0
+  resolution: "watchpack@npm:2.5.0"
   dependencies:
     glob-to-regexp: "npm:^0.4.1"
     graceful-fs: "npm:^4.1.2"
-  checksum: 10c0/6c0901f75ce245d33991225af915eea1c5ae4ba087f3aee2b70dd377d4cacb34bef02a48daf109da9d59b2d31ec6463d924a0d72f8618ae1643dd07b95de5275
+  checksum: 10c0/19944a2c05f8905b4b76dbbb317ae0efb18defa3eb7d3281caf1bb128c01302d00875a2fa0e48ec0242645d2e7e5c62c4efe8c60f9d30f176517f97dad1455f9
   languageName: node
   linkType: hard
 
@@ -3431,9 +3439,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:^5.101.3":
-  version: 5.103.0
-  resolution: "webpack@npm:5.103.0"
+"webpack@npm:^5.103.0":
+  version: 5.104.1
+  resolution: "webpack@npm:5.104.1"
   dependencies:
     "@types/eslint-scope": "npm:^3.7.7"
     "@types/estree": "npm:^1.0.8"
@@ -3443,10 +3451,10 @@ __metadata:
     "@webassemblyjs/wasm-parser": "npm:^1.14.1"
     acorn: "npm:^8.15.0"
     acorn-import-phases: "npm:^1.0.3"
-    browserslist: "npm:^4.26.3"
+    browserslist: "npm:^4.28.1"
     chrome-trace-event: "npm:^1.0.2"
-    enhanced-resolve: "npm:^5.17.3"
-    es-module-lexer: "npm:^1.2.1"
+    enhanced-resolve: "npm:^5.17.4"
+    es-module-lexer: "npm:^2.0.0"
     eslint-scope: "npm:5.1.1"
     events: "npm:^3.2.0"
     glob-to-regexp: "npm:^0.4.1"
@@ -3457,7 +3465,7 @@ __metadata:
     neo-async: "npm:^2.6.2"
     schema-utils: "npm:^4.3.3"
     tapable: "npm:^2.3.0"
-    terser-webpack-plugin: "npm:^5.3.11"
+    terser-webpack-plugin: "npm:^5.3.16"
     watchpack: "npm:^2.4.4"
     webpack-sources: "npm:^3.3.3"
   peerDependenciesMeta:
@@ -3465,7 +3473,7 @@ __metadata:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 10c0/d0cf86f8cac249874d6f36292e25011413ebb5bae82c48fa78a165a217e63db00b1a1f563f5195070eb17a055c6da4b6ab89fbdd37f781abdda862aa8c0bd623
+  checksum: 10c0/ea78c57f80bbd7684f4f1bb38a18408ab0ef4c5b962e25ad382c595d10b9e9701e077f5248a8cef5f127a55902698664c18837e64243bb972fbecf4e5d9aaab0
   languageName: node
   linkType: hard
 
@@ -3505,6 +3513,7 @@ __metadata:
     "@companion-module/base": "npm:~1.13"
     "@companion-module/tools": "npm:^2.1.1"
     "@types/node": "npm:^22.10.2"
+    "@types/ws": "npm:^8.18.1"
     debounce-fn: "npm:^6.0.0"
     eslint: "npm:^9.17.0"
     husky: "npm:^9.1.7"
@@ -3596,7 +3605,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zx@npm:^8.8.4":
+"zx@npm:^8.8.5":
   version: 8.8.5
   resolution: "zx@npm:8.8.5"
   bin:


### PR DESCRIPTION
This is the skeleton to provide support for CC buttons on the WING to trigger Companion actions.

The `SatelliteClient` is responsible for communicating and essentially implements the Satellite API. It should be kept agnostic to ports and hosts.

The `CustomCommandHandler` uses a `SatelliteClient` to register the surfaces and eventually to read the OSC messages and execute the button presses through the Satellite API.

## What is Missing
- parsing of OSC messages and pressing the corresponding buttons
- all non-user buttons on the consoles
- some configs

## Rambling
Furthermore, I tried something new with this more separated approach. I think this could be useful to some day clean up the main index.ts file by creating specific handler objects for tasks.

My vision is something like this:
```typescript
// index.ts

if(oscMessageIsCc) {
   customControlHandler.register(message)
}

variableHandler.register(message)
oscHandler.send(message)

```

Each of the handlers implements its own Timeout events to control the timing and can callback to the function that need to be executed on the level of Companion, e.g. `UpdateVariableDefinitions`

I think this will greatly help declutter the main file and will result in cleaner code for the future, as boundaries between functional parts will be clearer.
