### PR TITLE
Fix Feedbacks

### DIFF
--- a/src/handlers/connection-handler.ts
+++ b/src/handlers/connection-handler.ts
@@ -159,6 +159,7 @@ export class ConnectionHandler extends EventEmitter {
 			args: args,
 		}
 		this.osc.send(command)
+		this.osc.send({ address: cmd, args: [] }) // a bit ugly, but needed to keep the desk state up to date in companion
 		if (preventLog) return
 		this.logger?.debug(`Sending OSC command: ${command.address} ${argument ?? ''}`)
 	}


### PR DESCRIPTION
The console status is not kept properly. This probably comes from the prior deletion of a second OSC command with each command that is sent. 

Sending the second command without an argument makes the console reply with the current status for that path, which is then used by the module to update the internal status.

Since the console returns the status after an OSC command, I think there should be a way of parsing this return value to something useful. The problem currently is that not all returned values come in the form that we would expect.

Closes #174 