### PR TITLE
Fix Module Status Logic

### DIFF
--- a/src/handlers/connection-handler.ts
+++ b/src/handlers/connection-handler.ts
@@ -45,9 +45,9 @@ export class ConnectionHandler extends EventEmitter {
 			this.emit('ready')
 		})
 
-		this.osc.on('error', (err) => {
+		this.osc.on('error', (err: Error) => {
 			this.logger?.error(`OSC error: ${err.message}`)
-			this.emit('error')
+			this.emit('error', err)
 		})
 
 		this.osc.on('close' as any, () => {


### PR DESCRIPTION
The Companion module status logic seems to be flawed.

When a connection is initiated, the status is set to `InstanceStatus.Connecting` when the `ready` event from osc is received. This could lead to the module actually having an established connection but not showing it to the user, which could be confusing.

This PR addresses this by setting the status to `InstanceStatus.Connecting` earlier in the process and then setting it to `InstanceStatus.Ok` when the osc socket is ready.

This PR should close #173 and solve an issue from #175