### PR TITLE
Device detector failure no longer changes module status

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,8 +124,9 @@ export class WingInstance extends InstanceBase<WingConfig> implements InstanceBa
 		this.deviceDetector.subscribe(this.id)
 		if (this.deviceDetector) {
 			;(this.deviceDetector as any).on?.('no-device-detected', () => {
-				this.logger?.warn('No console detected on the network')
-				this.updateStatus(InstanceStatus.Disconnected, 'Unable to detect a console on the network')
+				this.logger?.warn(
+					'The device detector was not able to detect a console on the network. This behavior is normal when multiple network interfaces are active. The module is still functional.',
+				)
 			})
 		}
 	}


### PR DESCRIPTION
When multiple network interfaces are connected at a time, the device detector may fail to find a console on the network, because the OS relays traffic on 0.0.0.0 to the wrong network interface. The device detector not being able to detect a console no longer changes the module state to disconnected and only produces a logger warning.

Closes #228 